### PR TITLE
Fixed CTC positioning on multiple resolutions

### DIFF
--- a/src/Action/DialogAction.cs
+++ b/src/Action/DialogAction.cs
@@ -38,6 +38,7 @@ namespace TaleUtil
 
         private float timePerChar;
         private float clock;
+        private float screenToWorldUnit;
 
         private DialogAction() { }
 
@@ -84,7 +85,7 @@ namespace TaleUtil
             Vector3 bottomRight = contentTransform.TransformPoint(lastCharInfo.bottomRight);
             float baseline = contentTransform.TransformPoint(new Vector3(0, lastCharInfo.baseLine, 0)).y;
 
-            float x = bottomRight.x + xOffset;
+            float x = bottomRight.x + xOffset * screenToWorldUnit;
             float y = yOffset;
 
             if (alignment == TaleUtil.Config.CTCAlignment.MIDDLE)
@@ -148,6 +149,8 @@ namespace TaleUtil
                     {
                         state = State.BEGIN_WRITE;
                     }
+
+                    screenToWorldUnit = Screen.width / 1920f;
 
                     break;
                 }


### PR DESCRIPTION
CTC positioning worked only on 1920x1080 screens, so playing on a different resolution or entering play mode without a maximized screen would display weird CTC positioning. This pull request fixes this by taking screen width into account.